### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,11 @@ php:
     - 7.0
     - 7.1
     - 7.2
+    - nightly
+
+matrix:
+    allow_failures:
+        - php: nightly
 
 cache:
     directories:

--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,17 @@
         "php" : ">=5.6"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7",
+        "phpunit/phpunit": "^5.7 || ^6.5",
         "friendsofphp/php-cs-fixer": "^2.3"
     },
     "autoload": {
         "psr-4": {
             "PHLAK\\StrGen\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "PHLAK\\StrGen\\Tests\\": "tests/"
         }
     }
 }

--- a/tests/CharSetTest.php
+++ b/tests/CharSetTest.php
@@ -1,8 +1,11 @@
 <?php
 
-use PHLAK\StrGen;
+namespace PHPUnit\Framework\TestCase;
 
-class CharSetTest extends PHPUnit_Framework_TestCase
+use PHLAK\StrGen;
+use PHPUnit\Framework\TestCase;
+
+class CharSetTest extends TestCase
 {
     public function test_it_has_a_lower_alpha_characters_set()
     {

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -1,8 +1,11 @@
 <?php
 
-use PHLAK\StrGen;
+namespace PHLAK\StrGen\Tests;
 
-class GeneratorTest extends PHPUnit_Framework_TestCase
+use PHLAK\StrGen;
+use PHPUnit\Framework\TestCase;
+
+class GeneratorTest extends TestCase
 {
     public function test_it_can_be_initialized()
     {
@@ -16,22 +19,27 @@ class GeneratorTest extends PHPUnit_Framework_TestCase
         $generator = new StrGen\Generator;
 
         $default = $generator->generate();
+
+        $this->assertInternalType('string', $default);
+        $this->assertEquals(42, strlen($default));
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     */
     public function test_it_throws_an_exception_when_passing_an_invalid_type_to_charset()
     {
         $generator = new StrGen\Generator;
 
-        $this->setExpectedException(\InvalidArgumentException::class);
-
         $custom = $generator->charset(null);
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     */
     public function test_it_throws_an_exception_when_passing_an_invalid_type_to_length()
     {
         $generator = new StrGen\Generator;
-
-        $this->setExpectedException(\InvalidArgumentException::class);
 
         $custom = $generator->length(null);
     }


### PR DESCRIPTION
# Changed log
- Add ```php-nightly``` test in Travis CI build.
- Use the PHPUnit ```^5.7``` and ```6.5``` version to support the different PHP versions.
- Using the class-based PHPUnit namespace to be compatible with the stable PHPUnit version.
- The PHPUnit ```5.7``` version uses ```setExpcetedException``` and it's deprecated in version ```6.0+```.
To be compatible with this, we should use the ```expectedException``` annotation.