### PR TITLE
Set the PHPUnit 8.0 to be compatible with PHP-7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
     - 7.0
     - 7.1
     - 7.2
+    - 7.3
     - nightly
 
 matrix:

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "php" : ">=7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.0 || ^7.0",
+        "phpunit/phpunit": "^6.0 || ^7.0 || ^8.0",
         "friendsofphp/php-cs-fixer": "^2.3"
     },
     "autoload": {


### PR DESCRIPTION
# Changed log
- Add the `php-7.3` test on Travis CI build.
- Add the `PHPUnit 8.0` version to be compatible with `php-7.2+` version tests on Travis CI build.